### PR TITLE
Update PlaylistSorter.py

### DIFF
--- a/PlaylistSorter.py
+++ b/PlaylistSorter.py
@@ -1,27 +1,49 @@
 #!/usr/bin/env python3
 """
-Sort an iTunes Music Library XML playlist by a chosen Spotify track metadata attribute or local audio feature using Spotipy and Librosa.
+Sort an iTunes Music Library XML playlist by a chosen Spotify track metadata attribute,
+local audio feature, or embedded file metadata using Mutagen, Spotipy, and Librosa.
 Reads an iTunes Music Library XML (.xml), targets a playlist (optional), lets the user choose
-an attribute (e.g., popularity, duration_ms, explicit, track_number, disc_number, release_date,
-energy_local, brightness, percussiveness_zcr, percussiveness_onset, contrast, style_and_key_similarity,
-bpm, music_genre, harmonic_content_key, timbral_changes, dynamic_changes) and sort direction.
-Looks up each track's data on Spotify or analyzes the local file via Librosa, sorts the playlist accordingly,
-and writes a new XML file with the playlist reordered. The new playlist name in the XML will
-append ": sorted by <attribute>" to the original name.
-Defaults to the only playlist if none is specified; auto-generates the output filename.
-Verbose output shows fetched values and final sort order.
+an attribute and sort direction. Tries to read embedded metadata tags first; if not found,
+falls back to Spotify lookup or Librosa analysis. Writes a new XML file with the playlist reordered.
 """
-import os
 import sys
+import subprocess
+
+# --- Dependency check ---
+def check_dependencies():
+    import importlib.util
+    required = ['mutagen', 'librosa', 'numpy', 'spotipy']
+    missing = [pkg for pkg in required if importlib.util.find_spec(pkg) is None]
+    if missing:
+        resp = input(f"The following dependencies are missing: {', '.join(missing)}.\nInstall now? [y/N]: ").strip().lower()
+        if resp == 'y':
+            try:
+                subprocess.check_call([sys.executable, '-m', 'pip', 'install'] + missing)
+                print("Dependencies installed. Please restart the script.")
+            except Exception as e:
+                print(f"Failed to install dependencies: {e}")
+            sys.exit(0)
+        else:
+            print("Cannot proceed without dependencies. Exiting.")
+            sys.exit(1)
+
+check_dependencies()
+
+import os
 import argparse
 import xml.etree.ElementTree as ET
 import datetime
 import urllib.parse
+import warnings
 
-# Local audio analysis dependencies
-import librosa
+# suppress librosa/audioread and numpy warnings
+warnings.filterwarnings("ignore", message="PySoundFile failed.*")
+warnings.filterwarnings("ignore", category=FutureWarning)
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+
 import numpy as np
-
+import librosa
+from mutagen import File as MutagenFile
 import spotipy
 from spotipy.oauth2 import SpotifyClientCredentials, SpotifyOauthError
 from spotipy.exceptions import SpotifyException
@@ -32,21 +54,14 @@ CLIENT_SECRET = 'XXXXXXXX'
 
 # Available attributes
 ATTRIBUTES = [
+    # Embedded/file metadata (tags)
+    'title', 'artist', 'album', 'tracknumber', 'discnumber', 'genre',
     # Spotify metadata
-    'popularity',     # 0-100 popularity score
-    'release_date',   # album release date (YYYY-MM-DD or YYYY)
+    'popularity', 'release_date',
     # Local Librosa features
-    'energy_local',           # RMS energy
-    'brightness',             # spectral centroid
-    'percussiveness_zcr',     # zero-crossing rate
-    'percussiveness_onset',   # onset strength
-    'contrast',               # spectral contrast
-    'style_and_key_similarity', # tonal centroid (Tonnetz)
-    'bpm',                    # estimated tempo
-    'music_genre',            # MFCC average (proxy)
-    'harmonic_content_key',   # chroma STFT average
-    'timbral_changes',        # polynomial features average
-    'dynamic_changes',        # MFCC deltas average
+    'energy_local', 'brightness', 'percussiveness_zcr', 'percussiveness_onset',
+    'contrast', 'style_and_key_similarity', 'bpm', 'music_genre',
+    'harmonic_content_key', 'timbral_changes', 'dynamic_changes',
 ]
 
 SORT_DIRECTIONS = {
@@ -69,10 +84,10 @@ def load_library_tree(path):
                     tid = entries[i].text
                     info = entries[i+1]
                     data = {'Name': None, 'Artist': None, 'Location': None}
-                    info_children = list(info)
-                    for j in range(0, len(info_children), 2):
-                        k = info_children[j].text
-                        v = info_children[j+1].text
+                    children = list(info)
+                    for j in range(0, len(children), 2):
+                        k = children[j].text
+                        v = children[j+1].text
                         if k in data:
                             data[k] = v
                     tracks_map[tid] = data
@@ -108,14 +123,16 @@ def get_playlist_track_ids(pl_dict):
     for idx, elem in enumerate(list(pl_dict)):
         if elem.tag == 'key' and elem.text == 'Playlist Items':
             arr = list(pl_dict)[idx+1]
-            return [list(item)[1].text for item in list(arr) if list(item) and list(item)[0].text == 'Track ID']
+            return [list(item)[1].text for item in list(arr)
+                    if list(item) and list(item)[0].text == 'Track ID']
     return []
 
 def set_playlist_items(pl_dict, sorted_ids):
     for idx, elem in enumerate(list(pl_dict)):
         if elem.tag == 'key' and elem.text == 'Playlist Items':
             arr = list(pl_dict)[idx+1]
-            for child in list(arr): arr.remove(child)
+            for child in list(arr):
+                arr.remove(child)
             for tid in sorted_ids:
                 d = ET.SubElement(arr, 'dict')
                 ET.SubElement(d, 'key').text = 'Track ID'
@@ -124,17 +141,57 @@ def set_playlist_items(pl_dict, sorted_ids):
 
 def fetch_value(sp, artist, title, location, attr):
     """
-    Fetch a single attribute value: metadata via Spotipy, or local analysis via Librosa.
+    Fetch a single attribute: try embedded tags via Mutagen, then Spotify metadata, then Librosa analysis.
     """
-    # Local Librosa features
-    if location and attr.startswith(tuple(ATTRIBUTES[6:])):
+    path = None
+    if location:
         path = urllib.parse.unquote(location.replace('file://', ''))
+
+    # 1) Embedded metadata
+    if path:
+        try:
+            audio = MutagenFile(path, easy=True)
+            if audio and audio.tags:
+                tag_val = audio.tags.get(attr)
+                if tag_val:
+                    raw = tag_val[0]
+                    if attr in ('tracknumber','discnumber'):
+                        return int(raw.split('/')[0])
+                    try:
+                        return float(raw)
+                    except ValueError:
+                        return raw
+        except Exception as e:
+            print(f"[Metadata read error] {e}")
+
+    # 2) Spotify metadata
+    if attr in ('popularity','release_date'):
+        q = []
+        if artist: q.append(f'artist:"{artist}"')
+        if title:  q.append(f'track:"{title}"')
+        query = ' '.join(q) or title or artist
+        try:
+            res = sp.search(q=query, type='track', limit=1)
+            items = res['tracks']['items']
+            if not items:
+                return None
+            track = sp.track(items[0]['id'])
+            if attr == 'release_date':
+                rd = track.get('album', {}).get('release_date')
+                if not rd: return None
+                return datetime.date.fromisoformat(rd) if '-' in rd else datetime.date(int(rd),1,1)
+            return track.get(attr)
+        except SpotifyException as e:
+            print(f"[Spotify API Error] {e}")
+            return None
+
+    # 3) Local Librosa analysis
+    if path and attr not in ('popularity','release_date'):
         try:
             y, sr = librosa.load(path, sr=None)
         except Exception as e:
             print(f"[Local analysis error] {e}")
             return None
-        # Compute each feature
         if attr == 'energy_local':
             return float(np.mean(librosa.feature.rms(y=y)))
         if attr == 'brightness':
@@ -151,42 +208,16 @@ def fetch_value(sp, artist, title, location, attr):
             tempo, _ = librosa.beat.beat_track(y=y, sr=sr)
             return float(tempo)
         if attr == 'music_genre':
-            mfccs = librosa.feature.mfcc(y=y, sr=sr)
-            return float(np.mean(mfccs))
+            return float(np.mean(librosa.feature.mfcc(y=y, sr=sr)))
         if attr == 'harmonic_content_key':
-            chroma = librosa.feature.chroma_stft(y=y, sr=sr)
-            return float(np.mean(chroma))
+            return float(np.mean(librosa.feature.chroma_stft(y=y, sr=sr)))
         if attr == 'timbral_changes':
-            poly = librosa.feature.poly_features(y=y, sr=sr)
-            return float(np.mean(poly))
+            return float(np.mean(librosa.feature.poly_features(y=y, sr=sr)))
         if attr == 'dynamic_changes':
             mfccs = librosa.feature.mfcc(y=y, sr=sr)
-            delta = librosa.feature.delta(mfccs)
-            return float(np.mean(delta))
-    # Spotify metadata lookup
-    q = []
-    if artist: q.append(f'artist:"{artist}"')
-    if title:  q.append(f'track:"{title}"')
-    query = ' '.join(q) or title or artist
-    try:
-        res = sp.search(q=query, type='track', limit=1)
-        items = res['tracks']['items']
-        if not items:
-            return None
-        track = sp.track(items[0]['id'])
-        if attr == 'release_date':
-            rd = track.get('album', {}).get('release_date')
-            if not rd: return None
-            if len(rd) == 4:
-                return datetime.date(int(rd),1,1)
-            try:
-                return datetime.date.fromisoformat(rd)
-            except:
-                return None
-        return track.get(attr)
-    except SpotifyException as e:
-        print(f"[Spotify API Error] {e}")
-        return None
+            return float(np.mean(librosa.feature.delta(mfccs)))
+
+    return None
 
 def choose_attribute():
     print("Select a track attribute to sort by:")
@@ -197,7 +228,7 @@ def choose_attribute():
         return ATTRIBUTES[int(choice)-1]
     if choice in ATTRIBUTES:
         return choice
-    print(f"Invalid choice, defaulting to '{ATTRIBUTES[0]}'.")
+    print(f"Invalid choice, defaulting to '{ATTRIBUTES[0]}'")
     return ATTRIBUTES[0]
 
 def choose_direction():
@@ -211,21 +242,24 @@ def main():
     if not (CLIENT_ID and CLIENT_SECRET):
         print("✗ Please set CLIENT_ID and CLIENT_SECRET in the script.")
         sys.exit(1)
-    parser = argparse.ArgumentParser(description='Sort an iTunes XML playlist by attribute or local audio feature.')
-    parser.add_argument('input', help='Path to iTunes XML')
-    parser.add_argument('playlist', nargs='?', help='Playlist to sort')
-    parser.add_argument('output', nargs='?', help='Output XML path')
+
+    parser = argparse.ArgumentParser(description='Sort an iTunes XML playlist by attribute or feature.')
+    parser.add_argument('input',  help='Path to iTunes Music Library XML')
+    parser.add_argument('playlist', nargs='?', help='Playlist name to sort')
+    parser.add_argument('output',   nargs='?', help='Output XML path')
     args = parser.parse_args()
 
     tree, plist_dict, tracks_map = load_library_tree(args.input)
-    pname = args.playlist or (list_playlists(plist_dict)[0] if len(list_playlists(plist_dict))==1 else None)
+    playlists = list_playlists(plist_dict)
+    pname = args.playlist or (playlists[0] if len(playlists) == 1 else None)
     if not pname:
-        print(f"Available playlists: {list_playlists(plist_dict)}")
+        print(f"Available playlists: {playlists}")
         pname = input("Enter playlist name to sort: ")
     pl_dict = find_playlist_dict(plist_dict, pname)
     if pl_dict is None:
         print(f"✗ Playlist '{pname}' not found.")
         sys.exit(1)
+
     tids = get_playlist_track_ids(pl_dict)
     if not tids:
         print(f"✗ No tracks in playlist '{pname}'.")
@@ -233,10 +267,11 @@ def main():
 
     attr = choose_attribute()
     dir_name, reverse = choose_direction()
-    print(f"Sorting by: {attr} ({dir_name})\n")
+    print(f"\nSorting by: {attr} ({dir_name})\n")
 
     try:
-        auth = SpotifyClientCredentials(client_id=CLIENT_ID, client_secret=CLIENT_SECRET)
+        auth = SpotifyClientCredentials(client_id=CLIENT_ID,
+                                        client_secret=CLIENT_SECRET)
         sp = spotipy.Spotify(auth_manager=auth)
     except SpotifyOauthError as e:
         print(f"✗ Spotify authentication failed: {e}")
@@ -246,13 +281,19 @@ def main():
     print("Fetching values:")
     for tid in tids:
         info = tracks_map.get(tid, {})
-        val = fetch_value(sp, info.get('Artist'), info.get('Name'), info.get('Location'), attr)
+        val = fetch_value(sp,
+                          info.get('Artist'),
+                          info.get('Name'),
+                          info.get('Location'),
+                          attr)
         if val is None:
             print(f"⚠️ '{info.get('Name')}' missing '{attr}', placing last.")
+            # Use minimal for dates, infinity for numbers/strings
             val = datetime.date.min if attr=='release_date' else float('inf')
         print(f"  {info.get('Name')}: {attr} = {val}")
         scored.append((tid, val))
 
+    # sort and rewrite playlist
     sorted_pairs = sorted(scored, key=lambda x: x[1], reverse=reverse)
     print("\nFinal order:")
     for i, (tid, v) in enumerate(sorted_pairs, 1):
@@ -261,20 +302,16 @@ def main():
     sorted_ids = [tid for tid, _ in sorted_pairs]
     set_playlist_items(plist_dict, sorted_ids)
 
-    # Update playlist name with suffix
+    # update playlist name
     for idx, elem in enumerate(list(plist_dict)):
         if elem.tag == 'key' and elem.text == 'Playlists':
             arr = list(plist_dict)[idx+1]
             for pl in arr:
-                name_elem = None
                 pts = list(pl)
                 for j in range(len(pts)):
-                    if pts[j].tag == 'key' and pts[j].text == 'Name' and pts[j+1].text == pname:
-                        name_elem = pts[j+1]
+                    if pts[j].tag=='key' and pts[j].text=='Name' and pts[j+1].text==pname:
+                        pts[j+1].text = f"{pname} : sorted by {attr}"
                         break
-                if name_elem is not None:
-                    name_elem.text = f"{pname} : sorted by {attr}"
-                    break
             break
 
     out = args.output or os.path.splitext(args.input)[0] + '_sorted.xml'


### PR DESCRIPTION
What’s new :

Dependency pre-flight check
At startup it now checks for mutagen, librosa, numpy and spotipy and offers to install any that are missing, then exits so you can re-run with a complete environment. Unified attribute list
You can now sort by any of:
Embedded file tags (title, artist, album, tracknumber, discnumber, genre) Spotify metadata (popularity, release_date)
Local audio features (all your old Librosa metrics like energy_local, brightness, bpm, etc.) Three-stage lookup in fetch_value()
1. Try reading the attribute straight from the file’s embedded tags via Mutagen.
2. If it’s a Spotify field (popularity or release_date), query the Spotify API.
3. Otherwise fall back to your Librosa-based audio analysis for local-feature attributes. Integrated into playlist sorting
The same pipeline that once just pulled Librosa or Spotify values now slots into the iTunes-XML sorting script. Tracks with missing values get a warning and are pushed to the end of the playlist. No more separate visualizations or metadata-embed steps This script focuses purely on sorting the XML playlist; the music-analysis CLI’s PNG export and tag-writing lives on only within fetch_value() (it reads tags) but doesn’t itself generate charts or re-embed tags. Simplified command line
You now invoke with three positional arguments: the XML file, (optional) playlist name, and (optional) output path. All previous -PNG / metadata-embed logic has been rolled into the single fetch_value routine. In short, the new version merges your full-featured audio-analysis logic into the existing iTunes-XML sorter, adds a dependency installer, and unifies all lookup methods (embedded tags, Spotify, Librosa) under one fetch_value() interface.